### PR TITLE
Add MindDrop project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# dropmind
+# MindDrop
+
+MindDrop est un MVP d'application de soutien émotionnel géolocalisé. Ce dépôt contient un squelette de projet basé sur Laravel 11, Vue 3 et Leaflet.
+
+## Structure
+
+- `composer.json` et `package.json` : dépendances de base
+- `routes/api.php` : routes API pour les drops anonymes et l'IA
+- `app/Models` : modèles Eloquent (`MindDrop`, `Mood`, `UserToken`)
+- `app/Http/Controllers` : `MindDropController` et `IAController`
+- `app/Http/Middleware` : middleware de gestion du token anonyme
+- `database/migrations` : migrations de tables
+- `resources/js` : pages Vue (`MapPage.vue`, `DropPage.vue`)
+
+Ce code est incomplet mais sert de point de départ pour étendre l'application.

--- a/app/Http/Controllers/IAController.php
+++ b/app/Http/Controllers/IAController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class IAController extends Controller
+{
+    public function respond(Request $request)
+    {
+        // Call OpenAI to generate empathic response
+        return response()->json(['reply' => 'Réponse empathique']);
+    }
+
+    public function summary(Request $request)
+    {
+        // Summarize emotions in an area
+        return response()->json(['summary' => 'Résumé émotionnel']);
+    }
+}

--- a/app/Http/Controllers/MindDropController.php
+++ b/app/Http/Controllers/MindDropController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\MindDrop;
+use App\Models\UserToken;
+use App\Models\Mood;
+
+class MindDropController extends Controller
+{
+    public function token(Request $request)
+    {
+        // Generate anonymous token or return existing
+        return response()->json(['token' => 'demo-token']);
+    }
+
+    public function index(Request $request)
+    {
+        // List drops near coordinates
+        return response()->json(MindDrop::latest()->take(50)->get());
+    }
+
+    public function store(Request $request)
+    {
+        // Store a new drop
+        $drop = MindDrop::create($request->all());
+        return response()->json($drop, 201);
+    }
+
+    public function show(MindDrop $drop)
+    {
+        return response()->json($drop);
+    }
+
+    public function support(MindDrop $drop)
+    {
+        // Add support to drop
+        return response()->json(['supported' => true]);
+    }
+
+    public function report(MindDrop $drop)
+    {
+        // Report drop to moderators
+        return response()->json(['reported' => true]);
+    }
+}

--- a/app/Http/Middleware/AnonymousToken.php
+++ b/app/Http/Middleware/AnonymousToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class AnonymousToken
+{
+    public function handle(Request $request, Closure $next)
+    {
+        // Attach or generate anonymous token
+        if (!$request->header('X-MindDrop-Token')) {
+            $request->headers->set('X-MindDrop-Token', 'demo-token');
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/MindDrop.php
+++ b/app/Models/MindDrop.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MindDrop extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title', 'message', 'mood_id', 'lat', 'lng', 'image_path', 'token_id',
+    ];
+
+    public function mood()
+    {
+        return $this->belongsTo(Mood::class);
+    }
+
+    public function token()
+    {
+        return $this->belongsTo(UserToken::class, 'token_id');
+    }
+}

--- a/app/Models/Mood.php
+++ b/app/Models/Mood.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Mood extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name', 'emoji',
+    ];
+}

--- a/app/Models/UserToken.php
+++ b/app/Models/UserToken.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'token', 'ip_hash',
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "minddrop/minddrop",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_moods_table.php
+++ b/database/migrations/2024_01_01_000000_create_moods_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('moods', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('emoji');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('moods');
+    }
+};

--- a/database/migrations/2024_01_01_000100_create_user_tokens_table.php
+++ b/database/migrations/2024_01_01_000100_create_user_tokens_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('user_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->string('token');
+            $table->string('ip_hash')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_tokens');
+    }
+};

--- a/database/migrations/2024_01_01_000200_create_mind_drops_table.php
+++ b/database/migrations/2024_01_01_000200_create_mind_drops_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('mind_drops', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('message');
+            $table->foreignId('mood_id')->constrained();
+            $table->decimal('lat', 10, 7);
+            $table->decimal('lng', 10, 7);
+            $table->string('image_path')->nullable();
+            $table->foreignId('token_id')->constrained('user_tokens');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mind_drops');
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "minddrop",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "leaflet": "^1.9.4",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^5.0.0"
+  }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,0 +1,13 @@
+import { createApp } from 'vue';
+import MapPage from './pages/MapPage.vue';
+import DropPage from './pages/DropPage.vue';
+
+const routes = {
+  '/map': MapPage,
+  '/drop': DropPage,
+};
+
+const path = window.location.pathname;
+const Page = routes[path] || MapPage;
+
+createApp(Page).mount('#app');

--- a/resources/js/pages/DropPage.vue
+++ b/resources/js/pages/DropPage.vue
@@ -1,0 +1,29 @@
+<template>
+  <form class="p-4 space-y-2" @submit.prevent="submit">
+    <input v-model="title" type="text" placeholder="Titre" class="w-full border" />
+    <textarea v-model="message" placeholder="Message" class="w-full border"></textarea>
+    <select v-model="mood" class="w-full border">
+      <option value="1">😊 Joyeux</option>
+      <option value="2">😢 Triste</option>
+    </select>
+    <button class="bg-blue-600 text-white px-4 py-2">Déposer</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+
+const title = ref('');
+const message = ref('');
+const mood = ref('1');
+
+const submit = async () => {
+  await axios.post('/api/drops', {
+    title: title.value,
+    message: message.value,
+    mood_id: mood.value,
+  });
+  window.location.href = '/map';
+};
+</script>

--- a/resources/js/pages/MapPage.vue
+++ b/resources/js/pages/MapPage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="h-screen" id="map"></div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue';
+import L from 'leaflet';
+
+onMounted(() => {
+  const map = L.map('map').setView([48.8566, 2.3522], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+});
+</script>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MindDrop</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
+    <script type="module" src="/resources/js/app.js"></script>
+</head>
+<body class="bg-gray-900 text-gray-100">
+<div id="app"></div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\MindDropController;
+use App\Http\Controllers\IAController;
+
+Route::middleware('api')->group(function () {
+    Route::post('/token', [MindDropController::class, 'token']);
+
+    Route::get('/drops', [MindDropController::class, 'index']);
+    Route::post('/drops', [MindDropController::class, 'store']);
+    Route::get('/drops/{drop}', [MindDropController::class, 'show']);
+    Route::post('/drops/{drop}/support', [MindDropController::class, 'support']);
+    Route::post('/drops/{drop}/ai', [IAController::class, 'respond']);
+    Route::post('/drops/{drop}/report', [MindDropController::class, 'report']);
+
+    Route::post('/ai/summary', [IAController::class, 'summary']);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Laravel-inspired structure for MindDrop
- add placeholder models, controllers, middleware, migrations
- scaffold Vue pages with Leaflet map and drop form
- configure Vite and project metadata

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6a4ec498832f9dea7eebec703ae5